### PR TITLE
Remove unused hook

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -28,8 +28,6 @@ class Admin {
 	 */
 	public function __construct() {
 		add_filter( 'plugin_action_links', [ $this, 'add_action_link' ], 10, 2 );
-
-		add_action( 'publish_post', [ $this, 'insert_post' ] );
 		add_action( 'admin_menu', [ $this, 'admin_init' ] );
 		add_action( 'transition_post_status', [ $this, 'transition_post_status' ], 10, 3 );
 	}


### PR DESCRIPTION
This hook isn't used, the logic is all in `transition_post_status`.